### PR TITLE
Makes the polyfill compatible with the standard Headers class

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # `headers-utils`
 
-Utilities for creating and transforming a `Headers` instance.
+A `Headers` instance polyfill and transformation library.
 
 ## Motivation
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   transform: {
-    "^.+\\.tsx?$": "ts-jest",
+    '^.+\\.tsx?$': 'ts-jest',
   },
-  moduleFileExtensions: ["ts", "tsx", "js"],
-};
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "headers-utils",
   "version": "1.2.5",
-  "description": "Utilities for creating and transforming a Headers instance",
+  "description": "A Headers instance polyfill and transformation library.",
   "main": "lib/index.js",
   "types": "lib",
   "repository": "https://github.com/mswjs/headers-utils",

--- a/src/Headers.test.ts
+++ b/src/Headers.test.ts
@@ -1,200 +1,331 @@
-import { Headers } from './Headers'
+import Headers from './Headers'
 
-describe('Headers', () => {
-  describe('given I create a new Headers instance', () => {
-    describe('without any arguments', () => {
+describe('given I create a new Headers instance', () => {
+  describe('without any arguments', () => {
+    it('should return an empty object', () => {
+      const headers = new Headers()
+      expect(headers.getAllHeaders()).toEqual({})
+    })
+  })
+
+  describe('with initial headers object', () => {
+    it('should return that headers object', () => {
+      const headers = new Headers({ accept: '*/*' })
+      expect(headers.get('accept')).toEqual('*/*')
+    })
+  })
+
+  describe('with initial headers list', () => {
+    describe('with a single value', () => {
+      it('should set that value', () => {
+        const headers = new Headers([['accept', '*/*']])
+        expect(headers.get('accept')).toEqual('*/*')
+      })
+    })
+
+    describe('with multiple values represented as a list', () => {
+      it('should join values', () => {
+        const headers = new Headers([
+          ['accept', ['application/json', 'image/png']],
+        ])
+        expect(headers.get('accept')).toEqual('application/json, image/png')
+      })
+    })
+
+    describe('with multiple values represented as a string', () => {
+      it('should preserve values as-is', () => {
+        const headers = new Headers([['accept', 'application/json, image/png']])
+        expect(headers.get('accept')).toEqual('application/json, image/png')
+      })
+    })
+  })
+})
+
+describe('[Symbol.iterator]', () => {
+  describe('given a Headers instance with no headers set', () => {
+    it('returns an empty iterator', () => {
+      const headers = new Headers()
+      const entries = []
+
+      for (const entry of headers) {
+        entries.push(entry)
+      }
+
+      expect(entries).toEqual([])
+    })
+  })
+
+  describe('given a Headers instance with headers set', () => {
+    const headers = new Headers({
+      accept: '*/*',
+      'accept-language': 'en-US',
+      'content-type': 'application/json',
+    })
+
+    const entries = []
+
+    for (const entry of headers) {
+      entries.push(entry)
+    }
+
+    expect(entries).toEqual([
+      ['accept', '*/*'],
+      ['accept-language', 'en-US'],
+      ['content-type', 'application/json'],
+    ])
+  })
+})
+
+describe('.keys()', () => {
+  describe('given a Headers instance with no headers set', () => {
+    it('returns an empty iterator', () => {
+      const headers = new Headers()
+      const keys = []
+
+      for (const name of headers.keys()) {
+        keys.push(name)
+      }
+
+      expect(keys).toEqual([])
+    })
+  })
+
+  describe('given a Headers instance with headers set', () => {
+    it('returns the list of header names', () => {
+      const headers = new Headers({
+        accept: '*/*',
+        'accept-language': 'en-US',
+        'content-type': 'application/json',
+      })
+      const keys = []
+
+      for (const name of headers.keys()) {
+        keys.push(name)
+      }
+
+      expect(keys).toEqual(['accept', 'accept-language', 'content-type'])
+    })
+  })
+})
+
+describe('.values()', () => {
+  describe('given a Headers instance with no headers set', () => {
+    it('returns an empty iterator', () => {
+      const headers = new Headers()
+      const values = []
+
+      for (const value of headers.values()) {
+        values.push(value)
+      }
+
+      expect(values).toEqual([])
+    })
+  })
+
+  describe('given a Headers instance with headers set', () => {
+    it('returns the list of header values', () => {
+      const headers = new Headers({
+        accept: '*/*',
+        'accept-language': 'en-US',
+        'content-type': 'application/json',
+      })
+      const values = []
+
+      for (const value of headers.values()) {
+        values.push(value)
+      }
+
+      expect(values).toEqual(['*/*', 'en-US', 'application/json'])
+    })
+  })
+})
+
+describe('.entries()', () => {
+  describe('given a Headers instance with no headers set', () => {
+    it('returns an empty iterator', () => {
+      const headers = new Headers()
+      const entries = []
+
+      for (const entry of headers.entries()) {
+        entries.push(entry)
+      }
+
+      expect(entries).toEqual([])
+    })
+  })
+
+  describe('given a Headers instance with headers set', () => {
+    it('returns the list of header entries', () => {
+      const headers = new Headers({
+        accept: '*/*',
+        'accept-language': 'en-US',
+        'content-type': 'application/json',
+      })
+      const entries = []
+
+      for (const entry of headers.entries()) {
+        entries.push(entry)
+      }
+
+      expect(entries).toEqual([
+        ['accept', '*/*'],
+        ['accept-language', 'en-US'],
+        ['content-type', 'application/json'],
+      ])
+    })
+  })
+})
+
+describe('.get()', () => {
+  describe('given getting an existing header', () => {
+    it('should return that header value', () => {
+      const headers = new Headers({ accept: '*/*' })
+      expect(headers.get('accept')).toEqual('*/*')
+    })
+  })
+
+  describe('given getting a non-existing header', () => {
+    it('should return explicit null', () => {
+      const headers = new Headers({ accept: '*/*' })
+      expect(headers.get('content-type')).toBeNull()
+    })
+  })
+})
+
+describe('.getAllHeaders()', () => {
+  describe('given getting all the headers', () => {
+    describe('and the headers are empty', () => {
       it('should return an empty object', () => {
         const headers = new Headers()
         expect(headers.getAllHeaders()).toEqual({})
       })
     })
 
-    describe('with initial headers object', () => {
-      it('should return that headers object', () => {
+    describe('and the headers are present', () => {
+      const headers = new Headers({
+        accept: '*/*',
+        'content-type': ['application/json', 'text/plain'],
+      })
+      expect(headers.getAllHeaders()).toEqual({
+        accept: '*/*',
+        'content-type': 'application/json, text/plain',
+      })
+    })
+  })
+})
+
+describe('.set()', () => {
+  describe('given setting a new header', () => {
+    const headers = new Headers({ accept: '*/*' })
+    headers.set('content-type', 'application/json')
+
+    it('should preserve existing headers', () => {
+      expect(headers.get('accept')).toEqual('*/*')
+    })
+
+    it('should add the new header', () => {
+      expect(headers.get('content-type')).toEqual('application/json')
+    })
+  })
+
+  describe('given an existing header', () => {
+    const headers = new Headers({ accept: '*/*' })
+    headers.set('accept', 'image/png')
+
+    it('should override the existing header', () => {
+      expect(headers.get('accept')).toEqual('image/png')
+    })
+  })
+})
+
+describe('.append()', () => {
+  describe('given appending a new header', () => {
+    const headers = new Headers({ accept: '*/*' })
+    headers.append('content-type', 'application/json')
+
+    it('should preserve existing headers', () => {
+      expect(headers.get('accept')).toEqual('*/*')
+    })
+
+    it('should append the new header', () => {
+      expect(headers.get('content-type')).toEqual('application/json')
+    })
+  })
+
+  describe('given appending an existing header', () => {
+    const headers = new Headers({ accept: '*/*' })
+    headers.append('accept', 'image/png')
+
+    it('should join headers by comma', () => {
+      expect(headers.get('accept')).toEqual('*/*, image/png')
+    })
+  })
+})
+
+describe('.has()', () => {
+  describe('given looking for a header', () => {
+    describe('and that header exists', () => {
+      it('should return true', () => {
         const headers = new Headers({ accept: '*/*' })
-        expect(headers.get('accept')).toEqual('*/*')
-      })
-    })
-
-    describe('with initial headers list', () => {
-      describe('with a single value', () => {
-        it('should set that value', () => {
-          const headers = new Headers([['accept', '*/*']])
-          expect(headers.get('accept')).toEqual('*/*')
-        })
+        expect(headers.has('accept')).toBe(true)
       })
 
-      describe('with multiple values represented as a list', () => {
-        it('should join values', () => {
-          const headers = new Headers([
-            ['accept', ['application/json', 'image/png']],
-          ])
-          expect(headers.get('accept')).toEqual('application/json, image/png')
-        })
-      })
-
-      describe('with multiple values represented as a string', () => {
-        it('should preserve values as-is', () => {
-          const headers = new Headers([
-            ['accept', 'application/json, image/png'],
-          ])
-          expect(headers.get('accept')).toEqual('application/json, image/png')
-        })
-      })
-    })
-  })
-
-  describe('.get()', () => {
-    describe('given getting an existing header', () => {
-      it('should return that header value', () => {
-        const headers = new Headers({ accept: '*/*' })
-        expect(headers.get('accept')).toEqual('*/*')
-      })
-    })
-
-    describe('given getting a non-existing header', () => {
-      it('should return explicit null', () => {
-        const headers = new Headers({ accept: '*/*' })
-        expect(headers.get('content-type')).toBeNull()
-      })
-    })
-  })
-
-  describe('.getAllHeaders()', () => {
-    describe('given getting all the headers', () => {
-      describe('and the headers are empty', () => {
-        it('should return an empty object', () => {
-          const headers = new Headers()
-          expect(headers.getAllHeaders()).toEqual({})
-        })
-      })
-
-      describe('and the headers are present', () => {
-        const headers = new Headers({
-          accept: '*/*',
-          'content-type': ['application/json', 'text/plain'],
-        })
-        expect(headers.getAllHeaders()).toEqual({
-          accept: '*/*',
-          'content-type': 'application/json,text/plain',
-        })
-      })
-    })
-  })
-
-  describe('.set()', () => {
-    describe('given setting a new header', () => {
-      const headers = new Headers({ accept: '*/*' })
-      headers.set('content-type', 'application/json')
-
-      it('should preserve existing headers', () => {
-        expect(headers.get('accept')).toEqual('*/*')
-      })
-
-      it('should add the new header', () => {
-        expect(headers.get('content-type')).toEqual('application/json')
-      })
-    })
-
-    describe('given an existing header', () => {
-      const headers = new Headers({ accept: '*/*' })
-      headers.set('accept', 'image/png')
-
-      it('should override the existing header', () => {
-        expect(headers.get('accept')).toEqual('image/png')
-      })
-    })
-  })
-
-  describe('.append()', () => {
-    describe('given appending a new header', () => {
-      const headers = new Headers({ accept: '*/*' })
-      headers.append('content-type', 'application/json')
-
-      it('should preserve existing headers', () => {
-        expect(headers.get('accept')).toEqual('*/*')
-      })
-
-      it('should append the new header', () => {
-        expect(headers.get('content-type')).toEqual('application/json')
-      })
-    })
-
-    describe('given appending an existing header', () => {
-      const headers = new Headers({ accept: '*/*' })
-      headers.append('accept', 'image/png')
-
-      it('should join headers by comma', () => {
-        expect(headers.get('accept')).toEqual('*/*, image/png')
-      })
-    })
-  })
-
-  describe('.has()', () => {
-    describe('given looking for a header', () => {
-      describe('and that header exists', () => {
-        it('should return true', () => {
+      describe('and that header does not exist', () => {
+        it('should return false', () => {
           const headers = new Headers({ accept: '*/*' })
-          expect(headers.has('accept')).toBe(true)
-        })
-
-        describe('and that header does not exist', () => {
-          it('should return false', () => {
-            const headers = new Headers({ accept: '*/*' })
-            expect(headers.has('content-type')).toBe(false)
-          })
+          expect(headers.has('content-type')).toBe(false)
         })
       })
     })
   })
+})
 
-  describe('.delete()', () => {
-    describe('given deleting an existing header', () => {
-      it('should delete the header', () => {
-        const headers = new Headers({ accept: '*/*' })
-        headers.delete('accept')
-        expect(headers.get('accept')).toBeNull()
-      })
-    })
-
-    describe('given deleting a non-existing header', () => {
-      it('should do nothing', () => {
-        const headers = new Headers({ accept: '*/*' })
-        headers.delete('content-type')
-        expect(headers.get('accept')).toEqual('*/*')
-      })
+describe('.delete()', () => {
+  describe('given deleting an existing header', () => {
+    it('should delete the header', () => {
+      const headers = new Headers({ accept: '*/*' })
+      headers.delete('accept')
+      expect(headers.get('accept')).toBeNull()
     })
   })
 
-  describe('.forEach()', () => {
-    describe('given the traversal of each header', () => {
-      it('should traverse each header once', () => {
-        const headers = new Headers({ accept: '*/*', 'user-agent': 'agent' })
-        const headerSet = new Set()
-
-        headers.forEach((value, name, headers) => {
-          expect(value).toBe(headers.get(name))
-          expect(headerSet.has(name)).toBe(false)
-          headerSet.add(name)
-        })
-
-        expect(headerSet).toEqual(new Set(['accept', 'user-agent']))
-      })
+  describe('given deleting a non-existing header', () => {
+    it('should do nothing', () => {
+      const headers = new Headers({ accept: '*/*' })
+      headers.delete('content-type')
+      expect(headers.get('accept')).toEqual('*/*')
     })
+  })
+})
 
-    describe('given the traversal of each header with thisArg', () => {
-      it('should traverse each header once, with bind', () => {
-        const headers = new Headers({ accept: '*/*', 'user-agent': 'agent' })
-        const headerSet = new Set()
+describe('.forEach()', () => {
+  describe('given the traversal of each header', () => {
+    it('should traverse each header once', () => {
+      const headers = new Headers({ accept: '*/*', 'user-agent': 'agent' })
+      const headerSet = new Set()
 
-        headers.forEach(function (value, name, headers) {
-          expect(value).toBe(headers.get(name))
-          expect(this.has(name)).toBe(false)
-          this.add(name)
-        }, headerSet)
-
-        expect(headerSet).toEqual(new Set(['accept', 'user-agent']))
+      headers.forEach((value, name, headers) => {
+        expect(value).toBe(headers.get(name))
+        expect(headerSet.has(name)).toBe(false)
+        headerSet.add(name)
       })
+
+      expect(headerSet).toEqual(new Set(['accept', 'user-agent']))
+    })
+  })
+
+  describe('given the traversal of each header with thisArg', () => {
+    it('should traverse each header once, with bind', () => {
+      const headers = new Headers({ accept: '*/*', 'user-agent': 'agent' })
+      const headerSet = new Set()
+
+      headers.forEach(function (value, name, headers) {
+        expect(value).toBe(headers.get(name))
+        expect(this.has(name)).toBe(false)
+        this.add(name)
+      }, headerSet)
+
+      expect(headerSet).toEqual(new Set(['accept', 'user-agent']))
     })
   })
 })

--- a/src/flattenHeadersList.test.ts
+++ b/src/flattenHeadersList.test.ts
@@ -1,18 +1,16 @@
 import { HeadersList } from './glossary'
 import { flattenHeadersList } from './flattenHeadersList'
 
-describe('flattenHeadersList', () => {
-  describe('given a headers list', () => {
-    it('should flatten its multi-value headers', () => {
-      const headersList: HeadersList = [
-        ['accept', ['application/json', 'text/xml']],
-        ['content-type', 'application/pdf'],
-      ]
+describe('given a headers list', () => {
+  it('flattens its multi-value headers', () => {
+    const headersList: HeadersList = [
+      ['accept', ['application/json', 'text/xml']],
+      ['content-type', 'application/pdf'],
+    ]
 
-      expect(flattenHeadersList(headersList)).toEqual([
-        ['accept', 'application/json; text/xml'],
-        ['content-type', 'application/pdf'],
-      ])
-    })
+    expect(flattenHeadersList(headersList)).toEqual([
+      ['accept', 'application/json; text/xml'],
+      ['content-type', 'application/pdf'],
+    ])
   })
 })

--- a/src/flattenHeadersObject.test.ts
+++ b/src/flattenHeadersObject.test.ts
@@ -1,18 +1,16 @@
 import { flattenHeadersObject } from './flattenHeadersObject'
 import { HeadersObject } from './glossary'
 
-describe('flattenHeadersObject', () => {
-  describe('given a headers object', () => {
-    it('should flatten its multi-value headers', () => {
-      const headersObject: HeadersObject = {
-        Accept: ['application/json', 'text/xml'],
-        'Content-Type': 'application/pdf',
-      }
+describe('given a headers object', () => {
+  it('flattens its multi-value headers', () => {
+    const headersObject: HeadersObject = {
+      Accept: ['application/json', 'text/xml'],
+      'Content-Type': 'application/pdf',
+    }
 
-      expect(flattenHeadersObject(headersObject)).toEqual({
-        Accept: 'application/json; text/xml',
-        'Content-Type': 'application/pdf',
-      })
+    expect(flattenHeadersObject(headersObject)).toEqual({
+      Accept: 'application/json; text/xml',
+      'Content-Type': 'application/pdf',
     })
   })
 })

--- a/src/flattenHeadersObject.ts
+++ b/src/flattenHeadersObject.ts
@@ -1,9 +1,11 @@
 import { HeadersObject, FlatHeadersObject } from './glossary'
 import { reduceHeadersObject } from './reduceHeadersObject'
 
-export function flattenHeadersObject(obj: HeadersObject): FlatHeadersObject {
+export function flattenHeadersObject(
+  headersObject: HeadersObject
+): FlatHeadersObject {
   return reduceHeadersObject<FlatHeadersObject>(
-    obj,
+    headersObject,
     (headers, name, value) => {
       headers[name] = ([] as string[]).concat(value).join('; ')
       return headers

--- a/src/headersToList.node.test.ts
+++ b/src/headersToList.node.test.ts
@@ -1,15 +1,19 @@
+/**
+ * @jest-environment node
+ */
+import HeadersPolyfill from './Headers'
 import { headersToList } from './headersToList'
 
 describe('given Headers with a single header', () => {
   it('should return its list representation', () => {
-    const headers = new Headers({ Accept: 'application/json' })
+    const headers = new HeadersPolyfill({ Accept: 'application/json' })
     expect(headersToList(headers)).toEqual([['accept', 'application/json']])
   })
 })
 
 describe('given Headers with a single header and multiple values', () => {
   it('should return those values in a nested list', () => {
-    const headers = new Headers({ Accept: 'application/json' })
+    const headers = new HeadersPolyfill({ Accept: 'application/json' })
     headers.append('Accept', 'text/plain')
 
     expect(headersToList(headers)).toEqual([
@@ -20,7 +24,7 @@ describe('given Headers with a single header and multiple values', () => {
 
 describe('given Headers with various headers', () => {
   it('should return their list representation', () => {
-    const headers = new Headers({
+    const headers = new HeadersPolyfill({
       Accept: 'application/json',
       'Content-Length': '1234',
       'Content-Type': 'text/xml',

--- a/src/headersToList.ts
+++ b/src/headersToList.ts
@@ -5,7 +5,7 @@ export function headersToList(headers: Headers): HeadersList {
 
   headers.forEach((value, name) => {
     const resolvedValue = value.includes(',')
-      ? value.split(',').map((v) => v.trim())
+      ? value.split(',').map((value) => value.trim())
       : value
 
     headersList.push([name, resolvedValue])

--- a/src/headersToObject.node.test.ts
+++ b/src/headersToObject.node.test.ts
@@ -1,8 +1,12 @@
+/**
+ * @jest-environment node
+ */
+import HeadersPolyfill from './Headers'
 import { headersToObject } from './headersToObject'
 
 describe('given Headers with a single header', () => {
   it('should return that single header in an Object', () => {
-    const headers = new Headers({ 'Content-Type': 'application/json' })
+    const headers = new HeadersPolyfill({ 'Content-Type': 'application/json' })
     expect(headersToObject(headers)).toEqual({
       'content-type': 'application/json',
     })
@@ -11,7 +15,7 @@ describe('given Headers with a single header', () => {
 
 describe('given Headers with a single header and multiple values', () => {
   it('should put that header values into an array', () => {
-    const headers = new Headers({ Accept: 'application/json' })
+    const headers = new HeadersPolyfill({ Accept: 'application/json' })
     headers.append('Accept', 'text/plain')
 
     expect(headersToObject(headers)).toEqual({
@@ -22,7 +26,7 @@ describe('given Headers with a single header and multiple values', () => {
 
 describe('given Headers with multiple different headers', () => {
   it('should return an object representing those headers', () => {
-    const headers = new Headers({
+    const headers = new HeadersPolyfill({
       Accept: 'application/json',
       'Content-Length': '1234',
       'Content-Type': 'application/json',
@@ -39,7 +43,7 @@ describe('given Headers with multiple different headers', () => {
 
 describe('given Headers with a single header that includes a semicolon', () => {
   it('should preserve a single header', () => {
-    const headers = new Headers({
+    const headers = new HeadersPolyfill({
       'user-agent':
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.0 Safari/537.36',
     })

--- a/src/headersToString.test.ts
+++ b/src/headersToString.test.ts
@@ -1,8 +1,9 @@
+import { Headers as HeadersPolyfill } from '.'
 import { headersToString } from './headersToString'
 
 describe('headersToString', () => {
-  describe('given a Headers instance', () => {
-    it('should return its string representation', () => {
+  describe('given a standard Headers instance', () => {
+    it('returns its string representation', () => {
       const headers = new Headers({
         date: 'Fri, 08 Dec 2017 21:04:30 GMT',
         'content-encoding': 'gzip',
@@ -18,6 +19,28 @@ content-encoding: gzip\r
 content-length: 6502\r
 content-type: text/html; charset=utf-8\r
 date: Fri, 08 Dec 2017 21:04:30 GMT\r
+      `.trim()
+      )
+    })
+  })
+
+  describe('given a polyfill Headers instance', () => {
+    it('returns its string representation', () => {
+      const headers = new HeadersPolyfill({
+        date: 'Fri, 08 Dec 2017 21:04:30 GMT',
+        'content-encoding': 'gzip',
+        'content-type': 'text/html; charset=utf-8',
+        connection: 'keep-alive',
+        'content-length': '6502',
+      })
+
+      expect(headersToString(headers)).toEqual(
+        `
+date: Fri, 08 Dec 2017 21:04:30 GMT\r
+content-encoding: gzip\r
+content-type: text/html; charset=utf-8\r
+connection: keep-alive\r
+content-length: 6502\r
       `.trim()
       )
     })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { Headers } from './Headers'
+export { default as Headers } from './Headers'
 
 export { headersToString } from './headersToString'
 export { headersToList } from './headersToList'

--- a/src/listToHeaders.test.ts
+++ b/src/listToHeaders.test.ts
@@ -1,20 +1,19 @@
+import HeadersPolyfill from './Headers'
 import { listToHeaders } from './listToHeaders'
 import { HeadersList } from './glossary'
 
-describe('listToHeaders', () => {
-  describe('given a list representation of headers', () => {
-    it('should return a Headers instance', () => {
-      const list: HeadersList = [
-        ['accept', ['application/json', 'text/plain']],
-        ['content-length', '1234'],
-        ['content-type', 'application/json'],
-      ]
+describe('given a list representation of headers', () => {
+  it('returns a Headers instance', () => {
+    const list: HeadersList = [
+      ['accept', ['application/json', 'text/plain']],
+      ['content-length', '1234'],
+      ['content-type', 'application/json'],
+    ]
 
-      const headers = listToHeaders(list)
-      expect(headers).toBeInstanceOf(Headers)
-      expect(headers.get('accept')).toEqual('application/json, text/plain')
-      expect(headers.get('content-length')).toEqual('1234')
-      expect(headers.get('content-type')).toEqual('application/json')
-    })
+    const headers = listToHeaders(list)
+    expect(headers).toBeInstanceOf(HeadersPolyfill)
+    expect(headers.get('accept')).toEqual('application/json, text/plain')
+    expect(headers.get('content-length')).toEqual('1234')
+    expect(headers.get('content-type')).toEqual('application/json')
   })
 })

--- a/src/listToHeaders.ts
+++ b/src/listToHeaders.ts
@@ -1,7 +1,8 @@
+import HeadersPolyfill from './Headers'
 import { HeadersList } from './glossary'
 
-export function listToHeaders(list: HeadersList): Headers {
-  const headers = new Headers()
+export function listToHeaders(list: HeadersList): HeadersPolyfill {
+  const headers = new HeadersPolyfill()
 
   list.forEach(([name, value]) => {
     const values = ([] as string[]).concat(value)

--- a/src/objectToHeaders.test.ts
+++ b/src/objectToHeaders.test.ts
@@ -1,23 +1,21 @@
-import { Headers } from '.'
+import HeadersPolyfill from './Headers'
 import { objectToHeaders } from './objectToHeaders'
 import { HeadersObject } from './glossary'
 
-describe('objectToHeaders', () => {
-  describe('given an object representation of headers', () => {
-    it('should return a Headers instance', () => {
-      const headersObject: HeadersObject = {
-        Accept: ['application/json', 'text/plain'],
-        'Content-Length': '1234',
-        'Content-Type': 'text/xml',
-        'X-Custom-Header': undefined,
-      }
-      const headers = objectToHeaders(headersObject)
+describe('given an object representation of headers', () => {
+  it('returns a Headers instance', () => {
+    const headersObject: HeadersObject = {
+      Accept: ['application/json', 'text/plain'],
+      'Content-Length': '1234',
+      'Content-Type': 'text/xml',
+      'X-Custom-Header': undefined,
+    }
+    const headers = objectToHeaders(headersObject)
 
-      expect(headers).toBeInstanceOf(Headers)
-      expect(headers.get('accept')).toEqual('application/json, text/plain')
-      expect(headers.get('content-length')).toEqual('1234')
-      expect(headers.get('content-type')).toEqual('text/xml')
-      expect(headers.get('x-custom-header')).toBeNull()
-    })
+    expect(headers).toBeInstanceOf(HeadersPolyfill)
+    expect(headers.get('accept')).toEqual('application/json, text/plain')
+    expect(headers.get('content-length')).toEqual('1234')
+    expect(headers.get('content-type')).toEqual('text/xml')
+    expect(headers.get('x-custom-header')).toBeNull()
   })
 })

--- a/src/objectToHeaders.ts
+++ b/src/objectToHeaders.ts
@@ -1,14 +1,14 @@
-import { Headers } from './Headers'
+import HeadersPolyfill from './Headers'
 import { reduceHeadersObject } from './reduceHeadersObject'
 
 /**
  * Converts a given headers object to a new `Headers` instance.
  */
 export function objectToHeaders(
-  obj: Record<string, string | string[] | undefined>
-): Headers {
-  return reduceHeadersObject<Headers>(
-    obj,
+  headersObject: Record<string, string | string[] | undefined>
+): HeadersPolyfill {
+  return reduceHeadersObject(
+    headersObject,
     (headers, name, value) => {
       const values = ([] as string[]).concat(value).filter(Boolean)
 
@@ -18,6 +18,6 @@ export function objectToHeaders(
 
       return headers
     },
-    new Headers()
+    new HeadersPolyfill()
   )
 }

--- a/src/stringToHeaders.test.ts
+++ b/src/stringToHeaders.test.ts
@@ -1,10 +1,9 @@
 import { Headers } from '.'
 import { stringToHeaders } from './stringToHeaders'
 
-describe('stringToHeaders', () => {
-  describe('given a string representation of headers', () => {
-    it('should return a Headers instance', () => {
-      const headersString = `
+describe('given a string representation of headers', () => {
+  it('returns a Headers instance', () => {
+    const headersString = `
 date: Fri, 08 Dec 2017 21:04:30 GMT\r\n
 content-encoding: gzip\r\n
 x-content-type-options: nosniff\r\n
@@ -16,19 +15,18 @@ vary: Cookie, Accept-Encoding\r\n
 content-length: 6502\r\n
 x-xss-protection: 1; mode=block\r\n
       `
-      const headers = stringToHeaders(headersString)
+    const headers = stringToHeaders(headersString)
 
-      expect(headers).toBeInstanceOf(Headers)
-      expect(headers.get('date')).toEqual('Fri, 08 Dec 2017 21:04:30 GMT')
-      expect(headers.get('content-encoding')).toEqual('gzip')
-      expect(headers.get('x-content-type-options')).toEqual('nosniff')
-      expect(headers.get('server')).toEqual('meinheld/0.6.1')
-      expect(headers.get('x-frame-options')).toEqual('DENY')
-      expect(headers.get('content-type')).toEqual('text/html; charset=utf-8')
-      expect(headers.get('connection')).toEqual('keep-alive')
-      expect(headers.get('vary')).toEqual('Cookie, Accept-Encoding')
-      expect(headers.get('content-length')).toEqual('6502')
-      expect(headers.get('x-xss-protection')).toEqual('1; mode=block')
-    })
+    expect(headers).toBeInstanceOf(Headers)
+    expect(headers.get('date')).toEqual('Fri, 08 Dec 2017 21:04:30 GMT')
+    expect(headers.get('content-encoding')).toEqual('gzip')
+    expect(headers.get('x-content-type-options')).toEqual('nosniff')
+    expect(headers.get('server')).toEqual('meinheld/0.6.1')
+    expect(headers.get('x-frame-options')).toEqual('DENY')
+    expect(headers.get('content-type')).toEqual('text/html; charset=utf-8')
+    expect(headers.get('connection')).toEqual('keep-alive')
+    expect(headers.get('vary')).toEqual('Cookie, Accept-Encoding')
+    expect(headers.get('content-length')).toEqual('6502')
+    expect(headers.get('x-xss-protection')).toEqual('1; mode=block')
   })
 })

--- a/src/stringToHeaders.ts
+++ b/src/stringToHeaders.ts
@@ -1,17 +1,18 @@
-import { Headers } from './Headers'
+import HeadersPolyfill from './Headers'
 
 /**
  * Converts a string representation of headers (i.e. from XMLHttpRequest)
  * to a new `Headers` instance.
  */
-export function stringToHeaders(str: string): Headers {
+export function stringToHeaders(str: string): HeadersPolyfill {
   const lines = str.trim().split(/[\r\n]+/)
 
-  return lines.reduce<Headers>((headers, line) => {
+  return lines.reduce((headers, line) => {
     const parts = line.split(': ')
     const name = parts.shift()
     const value = parts.join(': ')
     headers.append(name, value)
+
     return headers
-  }, new Headers())
+  }, new HeadersPolyfill())
 }

--- a/src/utils/normalizeHeaderName.ts
+++ b/src/utils/normalizeHeaderName.ts
@@ -1,0 +1,13 @@
+const HEADERS_INVALID_CHARACTERS = /[^a-z0-9\-#$%&'*+.^_`|~]/i
+
+export function normalizeHeaderName(name: string): string {
+  if (typeof name !== 'string') {
+    name = String(name)
+  }
+
+  if (HEADERS_INVALID_CHARACTERS.test(name) || name.trim() === '') {
+    throw new TypeError('Invalid character in header field name')
+  }
+
+  return name.toLowerCase()
+}

--- a/src/utils/normalizeHeaderValue.ts
+++ b/src/utils/normalizeHeaderValue.ts
@@ -1,0 +1,7 @@
+export function normalizeHeaderValue(value: string): string {
+  if (typeof value !== 'string') {
+    value = String(value)
+  }
+
+  return value
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "declaration": true,
     "declarationDir": "lib",
     "moduleResolution": "node",
+    "downlevelIteration": true,
     "typeRoots": ["node_modules/@types"]
   },
   "include": ["src/**/*.ts"],


### PR DESCRIPTION
## Motivation

Currently, the polyfill `Headers` instance is not compatible with the standard `window.Headers`. The polyfill class misses the following methods:

- `[Symbol.iterator]`
- `.keys()`
- `.values()`
- `.entries()`

## Changes

- Adds the missing methods, making the polyfill class compatible with the `window.Headers` instance.
- Changes type signatures of transformation functions to accept the native `Headers` type (the type should be available). 
- Keeps the internal headers record in the `_headers` property (previously `_map`).
- Splits tests into `jsdom` ones that run against the standard Headers instance, and Node tests that run against the polyfill. Transformers should be able to handle both.