### PR TITLE
Headers: Uses "all" and "raw" methods instead of "getAllHeaders" and "getRawHeaders"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A `Headers` class polyfill and transformation library.
 
 Various request issuing libraries utilize a different format of headers. This library chooses the [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) instance as the middle-ground between server and client, and provides functions to convert that instance to primitives and vice-versa.
 
-## Getting started
+## Install
 
 ```bash
 $ npm install headers-utils
@@ -28,6 +28,55 @@ const headers = new Headers({
 })
 
 headers.get('accept') // "*/*"
+```
+
+## Methods
+
+The `Headers` polyfill instance supports the same methods as the standard `Headers` instance:
+
+- [`.has()`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/has)
+- [`.get()`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/get)
+- [`.set()`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/set)
+- [`.append()`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/append)
+- [`.delete()`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/delete)
+- `.forEach()`
+
+As well as the iterator methods:
+
+- [`.keys()`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/keys)
+- [`.values()`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/values)
+- [`.entries()`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/entries)
+
+### Custom methods
+
+In addition, the polyfill instance has the following methods:
+
+- `.all()`
+
+Returns the object of the _normalized_ header name/value pairs.
+
+```js
+const headers = new Headers({
+  Accept: '*/*',
+  'Content-Type': 'application/json',
+})
+
+headers.all()
+// { "accept": "*/*", "content-type": "application/json" }
+```
+
+- `.raw()`
+
+Similar to the `.all()` method, `.raw()` returns an object consisting of the header name/value pairs, but preserving raw header names.
+
+```js
+const headers = new Headers({
+  Accept: '*/*',
+  'Content-Type': 'application/json',
+})
+
+headers.raw()
+// { "Accept": "*/*", "Content-Type": "application/json" }
 ```
 
 ## Transformations

--- a/src/Headers.test.ts
+++ b/src/Headers.test.ts
@@ -3,12 +3,12 @@ import Headers from './Headers'
 describe('constructor()', () => {
   it('can be created without any arguments', () => {
     const headers = new Headers()
-    expect(headers.getAllHeaders()).toEqual({})
+    expect(headers.all()).toEqual({})
   })
 
   it('can be created given a Headers instance', () => {
     const headers = new Headers(new window.Headers({ Accept: '*/*' }))
-    expect(headers.getAllHeaders()).toEqual({ accept: '*/*' })
+    expect(headers.all()).toEqual({ accept: '*/*' })
   })
 
   it('can be created given a ["name", "a"] list', () => {
@@ -169,39 +169,39 @@ describe('.get()', () => {
   })
 })
 
-describe('.getAllHeaders()', () => {
+describe('.all()', () => {
   it('returns a headers object with normalized names', () => {
     const headers = new Headers({
       Accept: '*/*',
       'Content-Type': ['application/json', 'text/plain'],
     })
-    expect(headers.getAllHeaders()).toEqual({
+    expect(headers.all()).toEqual({
       accept: '*/*',
       'content-type': 'application/json, text/plain',
     })
   })
 
   it('returns an empty object when there is no headers', () => {
-    expect(new Headers().getAllHeaders()).toEqual({})
-    expect(new Headers({}).getAllHeaders()).toEqual({})
+    expect(new Headers().all()).toEqual({})
+    expect(new Headers({}).all()).toEqual({})
   })
 })
 
-describe('.getRawHeaders()', () => {
+describe('.raw()', () => {
   it('returns a headers objects with the raw names', () => {
     const headers = new Headers({
       Accept: '*/*',
       'ConTent-Type': ['application/json', 'text/plain'],
     })
-    expect(headers.getRawHeaders()).toEqual({
+    expect(headers.raw()).toEqual({
       Accept: '*/*',
       'ConTent-Type': 'application/json, text/plain',
     })
   })
 
   it('returns an empty object when there is no headers', () => {
-    expect(new Headers().getRawHeaders()).toEqual({})
-    expect(new Headers({}).getRawHeaders()).toEqual({})
+    expect(new Headers().raw()).toEqual({})
+    expect(new Headers({}).raw()).toEqual({})
   })
 })
 

--- a/src/Headers.ts
+++ b/src/Headers.ts
@@ -93,16 +93,16 @@ export default class HeadersPolyfill {
   }
 
   /**
-   * Returns the map of all the headers.
+   * Returns the object of all the normalized headers.
    */
-  getAllHeaders(): Record<string, string> {
+  all(): Record<string, string> {
     return this._headers
   }
 
   /**
-   * Returns the map of all the raw headers.
+   * Returns the object of all the raw headers.
    */
-  getRawHeaders(): Record<string, string> {
+  raw(): Record<string, string> {
     return Object.entries(this._headers).reduce((headers, [name, value]) => {
       headers[this._names.get(name)] = value
       return headers


### PR DESCRIPTION
## GitHub

- Follow-up of #11 

## Changes

```diff
-Headers.getAllHeaders()
+Headers.all()

-Headers.getRawHeaders()
+Headers.raw()
```

- Improves README by mentioning how to use the polyfill, its common and custom methods. 